### PR TITLE
2FE0 file splits

### DIFF
--- a/beetleadventurerac.us.yaml
+++ b/beetleadventurerac.us.yaml
@@ -81,10 +81,14 @@ segments:
       - [0x1D60, asm]
       - [0x1F60, c]
       - [0x2FE0, c]
+      - [0x32B0, c, memory]
+      - [0x3630, c]
       - [0x5740, c]
       - [0x6180, asm] 
       - [0x1A930, data]
-      - { type: bss, vram: 0x80022BD0 }
+      - { start: 0x237D0, type: bss, vram: 0x80022BD0, name: bss_1 }
+      - { start: 0x237D0, type: .bss, vram: 0x8002D9C0, name: 2FE0 }
+      - { start: 0x237D0, type: bss, vram: 0x8002DA60, name: bss_2 }
 
 #  - type: bin
 #    start: 0x237D0

--- a/diff_settings.py
+++ b/diff_settings.py
@@ -2,7 +2,7 @@ import os
 
 def apply(config, args):
     basename = 'beetleadventurerac'
-    if os.path.exists(f'build/{basename}.us.rev0.bin'):
+    if os.path.exists(f'build/{basename}.us.bin'):
         version = 'us'
     elif os.path.exists(f'build/{basename}.eu.bin'):
         version = 'eu'
@@ -10,6 +10,6 @@ def apply(config, args):
         version = 'us'
 
     config['baseimg'] = f'beetle.z64'
-    config['myimg'] = f'build/{basename}.{version}.rev1.z64'
-    config['mapfile'] = f'build/{basename}.{version}.rev1.map'
+    config['myimg'] = f'build/{basename}.{version}.z64'
+    config['mapfile'] = f'build/{basename}.{version}.map'
     config['source_directories'] = ['src', 'include']

--- a/first_diff.py
+++ b/first_diff.py
@@ -46,8 +46,8 @@ def firstDiffMain():
 
     buildFolder = Path("build")
 
-    BUILTROM = Path(buildFolder / f"beetleadventurerac.us.rev0.z64")
-    BUILTMAP = buildFolder / f"beetleadventurerac.us.rev0.map"
+    BUILTROM = Path(buildFolder / f"beetleadventurerac.us.z64")
+    BUILTMAP = buildFolder / f"beetleadventurerac.us.map"
 
     EXPECTEDROM = Path("beetle.z64")
     EXPECTEDMAP = "expected" / BUILTMAP

--- a/include/common.h
+++ b/include/common.h
@@ -1,5 +1,6 @@
 #ifndef BAR_COMMON_H
 #define BAR_COMMON_H
 #include <ultra64.h>
+#include "form.h"
 #include "functions.h"
 #endif // BAR_COMMON_H

--- a/include/form.h
+++ b/include/form.h
@@ -1,0 +1,10 @@
+#ifndef BAR_FORM_H
+#define BAR_FORM_H
+typedef struct FormFileInfo_s {
+    /* 0x00 */ u8* fileData;
+    /* 0x04 */ u32 padType; 
+    /* 0x08 */ s32 fileSize; // File size couting the first eight bytes
+    /* 0x0C */ u32 padTagStart; 
+} FormFileInfo;                               /* size = 0x10 */
+
+#endif /* BAR_FORM_H */

--- a/include/functions.h
+++ b/include/functions.h
@@ -1,5 +1,8 @@
 #ifndef BAR_FUNCTIONS_H
 #define BAR_FUNCTIONS_H
+s32 func_800023E0(u8* data);
+u64 uvMemRead(void* vAddr, u32 nbytes);
 void _uvDMA(void* vAddr, u32 devAddr, u32 nbytes);
 void _uvMediaCopy(void* vAddr, void* devAddr, u32 nbytes);
+void uvMemSet(void* vAddr, u8 value, u32 nbytes);
 #endif /* BAR_FUNCTIONS_H */

--- a/linker_scripts/us/symbol_addrs.txt
+++ b/linker_scripts/us/symbol_addrs.txt
@@ -23,6 +23,7 @@ uvstring_rom = 0x8008E340; // type:func rom:0x16E468
 uvMemRead =  0x80002890;
 _uvMediaCopy = 0x800026B0;
 _uvDMA = 0x800053AC;
+uvMemSet = 0x8000285C;
 mio0Decode = 0x80005590;
 D_80200000 = 0x80200000;
 D_80200280 = 0x80200280;

--- a/src/1F60.c
+++ b/src/1F60.c
@@ -1,5 +1,6 @@
 #include "common.h"
 
+
 #pragma GLOBAL_ASM("asm/us/nonmatchings/1F60/formLoader.s")
 
 #pragma GLOBAL_ASM("asm/us/nonmatchings/1F60/func_800015D4.s")

--- a/src/2FE0.c
+++ b/src/2FE0.c
@@ -1,186 +1,92 @@
 #include "common.h"
 
-#pragma GLOBAL_ASM("asm/us/nonmatchings/2FE0/func_800023E0.s")
+static FormFileInfo D_8002D9C0[10];
 
-#pragma GLOBAL_ASM("asm/us/nonmatchings/2FE0/func_80002484.s")
+void func_80002694(s32);                               /* extern */
 
-#pragma GLOBAL_ASM("asm/us/nonmatchings/2FE0/func_800024A8.s")
-
-#pragma GLOBAL_ASM("asm/us/nonmatchings/2FE0/func_800024BC.s")
-
-#pragma GLOBAL_ASM("asm/us/nonmatchings/2FE0/func_800024D0.s")
-
-#pragma GLOBAL_ASM("asm/us/nonmatchings/2FE0/func_800024E4.s")
-
-#pragma GLOBAL_ASM("asm/us/nonmatchings/2FE0/func_800025C8.s")
-
-#pragma GLOBAL_ASM("asm/us/nonmatchings/2FE0/func_80002694.s")
-
-void _uvMediaCopy(void* vAddr, void* devAddr, u32 nbytes) {
+s32 func_800023E0(u8* data) {
+    FormFileInfo* form;
     s32 i;
-    u8 *alignCeil;
-    s32 alignDiff;
-    u8 *src; // s1
-    u8 buf[16];
-    u8 *dst; // s2
-    // nbytes -> s0
-    s32 temp_a2;
-    s32 temp_v0;
-
-    dst = vAddr;
-    src = devAddr;
-    if ((u32)src & 0x80000000) {
-        for (i = 0; (u32)i < nbytes; i++) {
-            dst[i] = src[i];
+    
+    for (form = D_8002D9C0, i = 0; i < 10; i++, form++) {
+        if (form->fileData == NULL) {
+            break;
         }
-        return;
     }
 
-    while (nbytes > 0x1000) {
-        _uvMediaCopy(dst, src, 0x1000);
-        nbytes -= 0x1000;
-        dst += 0x1000;
-        src += 0x1000;
+    if (i == 10) {
+        *(s32*)0 = 0;
+        return -1;
     }
+    
+    form->fileData = data;
+    form->fileSize = uvMemRead(&data[4], 4) + 8; // Read the file size from the header and add the first eight bytes.
+    form->padType = uvMemRead(&data[8], 4);
+    func_80002694(i);
+    return i;
+}
 
-    if (nbytes != 0) {
-        if (((s32)src | (s32) dst | nbytes) & 1) {
-            // it appears the devs intended to cause a fault by storing to an unaligned address,
-            // but IDO outsmarted them and broke this into two `sb` instructions
-            // Debug Print removed..
-            *(u16*)(1) = 0;
-            return;
-        }
-        if ((s32)dst & 7) {
-            alignCeil = (u8*)((s32)(dst + 7) & ~7);
-            alignDiff = alignCeil - dst;
-            temp_a2 = (u32)src & 2;
-            
-            if ((nbytes != (u32)alignDiff) != 0) {
-                _uvDMA(alignCeil, src + alignDiff, nbytes - alignDiff);
-            }
-            temp_v0 = src - temp_a2;
-            
-            osPiWriteIo(temp_v0, &buf[0]);
-            osPiWriteIo(temp_v0 + 4, &buf[4]);
-            if (temp_a2) {
-                osPiWriteIo(temp_v0 + 8, &buf[8]);
-            }
-            for (i = 0; i < alignDiff && i < nbytes; i++) {
-                dst[i] = buf[i + temp_a2];
-            }
-            
-        } else {
-            _uvDMA(dst, src, nbytes);
-        }
+void func_80002484(s32 arg0) {
+    if ((arg0 >= 0) && (arg0 < 10)) {
+        D_8002D9C0[arg0].fileData = NULL;
     }
 }
 
-#pragma GLOBAL_ASM("asm/us/nonmatchings/2FE0/func_8000285C.s")
-
-#pragma GLOBAL_ASM("asm/us/nonmatchings/2FE0/uvMemRead.s")
-
-#pragma GLOBAL_ASM("asm/us/nonmatchings/2FE0/func_80002A30.s")
-
-#pragma GLOBAL_ASM("asm/us/nonmatchings/2FE0/func_80002A88.s")
-
-#pragma GLOBAL_ASM("asm/us/nonmatchings/2FE0/func_80002AC8.s")
-
-#pragma GLOBAL_ASM("asm/us/nonmatchings/2FE0/func_80002AEC.s")
-
-#pragma GLOBAL_ASM("asm/us/nonmatchings/2FE0/func_80002B2C.s")
-
-#pragma GLOBAL_ASM("asm/us/nonmatchings/2FE0/func_80002B80.s")
-
-#pragma GLOBAL_ASM("asm/us/nonmatchings/2FE0/func_80002CD0.s")
-
-#pragma GLOBAL_ASM("asm/us/nonmatchings/2FE0/func_80002EAC.s")
-
-#pragma GLOBAL_ASM("asm/us/nonmatchings/2FE0/func_80002F4C.s")
-
-#pragma GLOBAL_ASM("asm/us/nonmatchings/2FE0/func_80002F6C.s")
-
-#pragma GLOBAL_ASM("asm/us/nonmatchings/2FE0/func_800031A8.s")
-
-#pragma GLOBAL_ASM("asm/us/nonmatchings/2FE0/func_80003240.s")
-
-#pragma GLOBAL_ASM("asm/us/nonmatchings/2FE0/func_80003294.s")
-
-#pragma GLOBAL_ASM("asm/us/nonmatchings/2FE0/func_800032C4.s")
-
-#pragma GLOBAL_ASM("asm/us/nonmatchings/2FE0/func_800032E4.s")
-
-#pragma GLOBAL_ASM("asm/us/nonmatchings/2FE0/func_80003310.s")
-
-#pragma GLOBAL_ASM("asm/us/nonmatchings/2FE0/func_80003494.s")
-
-#pragma GLOBAL_ASM("asm/us/nonmatchings/2FE0/func_800034E0.s")
-
-#pragma GLOBAL_ASM("asm/us/nonmatchings/2FE0/func_80003520.s")
-
-#pragma GLOBAL_ASM("asm/us/nonmatchings/2FE0/func_8000355C.s")
-
-#pragma GLOBAL_ASM("asm/us/nonmatchings/2FE0/func_80003584.s")
-
-#pragma GLOBAL_ASM("asm/us/nonmatchings/2FE0/func_80003760.s")
-
-#pragma GLOBAL_ASM("asm/us/nonmatchings/2FE0/func_80003790.s")
-
-#pragma GLOBAL_ASM("asm/us/nonmatchings/2FE0/func_80003A14.s")
-
-#pragma GLOBAL_ASM("asm/us/nonmatchings/2FE0/func_80003AF0.s")
-
-#pragma GLOBAL_ASM("asm/us/nonmatchings/2FE0/func_80003B64.s")
-
-#pragma GLOBAL_ASM("asm/us/nonmatchings/2FE0/func_80003B80.s")
-
-#pragma GLOBAL_ASM("asm/us/nonmatchings/2FE0/func_80003C1C.s")
-
-#pragma GLOBAL_ASM("asm/us/nonmatchings/2FE0/func_80003CEC.s")
-
-#pragma GLOBAL_ASM("asm/us/nonmatchings/2FE0/func_80003E0C.s")
-
-#pragma GLOBAL_ASM("asm/us/nonmatchings/2FE0/func_80003E94.s")
-
-#pragma GLOBAL_ASM("asm/us/nonmatchings/2FE0/func_80003F04.s")
-
-#pragma GLOBAL_ASM("asm/us/nonmatchings/2FE0/func_80004014.s")
-
-#pragma GLOBAL_ASM("asm/us/nonmatchings/2FE0/func_80004088.s")
-
-#pragma GLOBAL_ASM("asm/us/nonmatchings/2FE0/func_80004274.s")
-
-#pragma GLOBAL_ASM("asm/us/nonmatchings/2FE0/func_80004284.s")
-
-#pragma GLOBAL_ASM("asm/us/nonmatchings/2FE0/func_80004298.s")
-
-#pragma GLOBAL_ASM("asm/us/nonmatchings/2FE0/func_800042DC.s")
-
-#pragma GLOBAL_ASM("asm/us/nonmatchings/2FE0/func_800042E4.s")
-
-#pragma GLOBAL_ASM("asm/us/nonmatchings/2FE0/func_800043E4.s")
-
-#pragma GLOBAL_ASM("asm/us/nonmatchings/2FE0/func_800046EC.s")
-
-#pragma GLOBAL_ASM("asm/us/nonmatchings/2FE0/func_8000481C.s")
-
-#pragma GLOBAL_ASM("asm/us/nonmatchings/2FE0/func_8000487C.s")
-
-#pragma GLOBAL_ASM("asm/us/nonmatchings/2FE0/func_800048C8.s")
-
-#pragma GLOBAL_ASM("asm/us/nonmatchings/2FE0/func_800048D4.s")
-
-void func_800048DC(void) {
+u8* func_800024A8(s32 arg0) {
+    return D_8002D9C0[arg0].fileData;
 }
 
-#pragma GLOBAL_ASM("asm/us/nonmatchings/2FE0/func_800048E4.s")
+s32 func_800024BC(s32 arg0) {
+    return D_8002D9C0[arg0].fileSize;
+}
 
-#pragma GLOBAL_ASM("asm/us/nonmatchings/2FE0/func_80004958.s")
+s32 func_800024D0(s32 arg0) {
+    return D_8002D9C0[arg0].padType;
+}
 
-#pragma GLOBAL_ASM("asm/us/nonmatchings/2FE0/func_80004A78.s")
 
-#pragma GLOBAL_ASM("asm/us/nonmatchings/2FE0/func_80004A84.s")
+u32 func_800024E4(s32 arg0, u32* arg1, s32* arg2) {
+    u32 currentTag;
+    s32 pad;
+    u32 localStack;
+    
 
-#pragma GLOBAL_ASM("asm/us/nonmatchings/2FE0/func_80004B1C.s")
+    if (arg1 == NULL) {
+        arg1 = &localStack;
+    }
+    if ((u32) D_8002D9C0[arg0].padTagStart >= (u32) D_8002D9C0[arg0].fileSize) {
+        return 0U;
+    }
+    do {
+        currentTag = uvMemRead(D_8002D9C0[arg0].padTagStart + D_8002D9C0[arg0].fileData, 4U);
+        *arg1 = uvMemRead(D_8002D9C0[arg0].padTagStart + D_8002D9C0[arg0].fileData + 4, 4U);
+        *arg2 = D_8002D9C0[arg0].padTagStart + D_8002D9C0[arg0].fileData  + 8;
 
-#pragma GLOBAL_ASM("asm/us/nonmatchings/2FE0/func_80004B2C.s")
+        D_8002D9C0[arg0].padTagStart += *arg1 + 8;
+    } while (currentTag == 'PAD ');
+    return currentTag;
+}
+
+u32 func_800025C8(s32 arg0, u32* arg1, s32* arg2, s32 arg3, s32 arg4) {
+    s32 var_s0;
+    u32 ret;
+    s32 temp;
+    u32 sp38;
+
+    var_s0 = 0;
+    sp38 = D_8002D9C0[arg0].padTagStart;
+    func_80002694(arg0);
+
+    while ((ret = func_800024E4(arg0, arg1, arg2)) != 0) {
+        temp = ret;
+        if ((temp == arg3) && (var_s0++ >= arg4)) {
+            break;
+        }
+    }
+    D_8002D9C0[arg0].padTagStart = sp38;
+    return ret;
+}
+
+void func_80002694(s32 arg0) {
+    D_8002D9C0[arg0].padTagStart = 12;
+}

--- a/src/3630.c
+++ b/src/3630.c
@@ -1,0 +1,206 @@
+#include "common.h"
+
+typedef struct UnkStruct_8002DA60_s {
+    /* 0x0 */ struct UnkStruct_8002DA60_s* unk0;                             /* inferred */
+    /* 0x4 */ s32 unk4;
+} UnkStruct_8002DA60;                               /* size = 0x8 */
+
+void func_80002A88(void);                                  /* extern */
+void func_80002AEC(s32);                                /* extern */
+void func_80002B2C(s32);                                /* extern */
+extern u8 D_8001F7D0;
+extern s32 D_8002F7D8;
+extern UnkStruct_8002DA60* D_8002DA60;
+extern UnkStruct_8002DA60 D_80033770[];
+
+extern s32 D_8001F7A0;
+extern s32 D_8001F7A4;
+
+
+void func_80002A30(void) {
+    func_80002A88();
+    if ((D_8002F7D8 != 0) || (D_8001F7D0 != 0)) {
+        func_80002B2C(D_8001F7D0);
+        func_80002AEC(D_8001F7D0);
+    }
+}
+
+void func_80002A88(void) {
+    D_8002DA60 = D_80033770;
+    D_8002DA60->unk0 = NULL;
+    D_8002DA60->unk4 = ((u32) 0x80400000) - ((u32) D_80033770);
+    D_8001F7A0 = 1;
+    D_8001F7A4 = 1;
+}
+
+void func_80002AC8(void) {
+    UnkStruct_8002DA60 *var_v0;
+
+    var_v0 = D_8002DA60;
+    while (var_v0 != NULL) {
+        var_v0 = var_v0->unk0;
+    }
+}
+
+#pragma GLOBAL_ASM("asm/us/nonmatchings/3630/func_80002AEC.s")
+
+void func_80002B2C(s32 arg0) {
+    UnkStruct_8002DA60* var_s0;
+
+    for (var_s0 = D_8002DA60; var_s0 != NULL; var_s0 = var_s0->unk0) {
+        uvMemSet(var_s0 + 1, arg0 & 0xFF & 0xFF, var_s0->unk4 - 8);
+    }
+}
+
+void func_80002B80(UnkStruct_8002DA60* arg0) {
+    UnkStruct_8002DA60* var_a2;
+    UnkStruct_8002DA60* var_v0;
+    s32 temp_v1;
+
+    var_v0 = NULL;
+    temp_v1 = arg0->unk4;
+    if (D_8002DA60 == NULL) {
+        D_8002DA60 = arg0;
+        D_8001F7A0 += 1;
+        return;
+    }
+
+    var_a2 = D_8002DA60;
+    while (var_a2 != NULL && var_a2 < arg0) {
+        var_v0 = var_a2;
+        var_a2 = var_a2->unk0;
+    }
+    
+    if (var_v0 != NULL) {
+        if ((u32)arg0 == ( (u32) var_v0 + (u32)var_v0->unk4)) {
+            if ((u32)var_a2 == ((u32)arg0 + (u32)temp_v1)) {
+                var_v0->unk4 += temp_v1;
+                var_v0->unk4 = var_v0->unk4 + var_a2->unk4;
+                var_v0->unk0 = var_a2->unk0;
+                D_8001F7A0 -= 1;
+                return;
+            }
+        }
+    }
+    if (var_v0 != NULL) {
+        if ((u32)arg0 == ((u32)var_v0 + (u32)var_v0->unk4)) {
+            var_v0->unk4 += temp_v1;
+            return;
+        }
+    }
+    if ((u32)var_a2 == ((u32)arg0 + temp_v1)) {
+        arg0->unk0 = var_a2->unk0;
+        
+        arg0->unk4 = (0, temp_v1) + var_a2->unk4; // FAKE
+        if (var_v0 != NULL) {
+            var_v0->unk0 = arg0;
+            return;
+        }
+        D_8002DA60 = arg0;
+        return;
+    }
+    arg0->unk0 = var_a2;
+    if (var_v0 != NULL) {
+        var_v0->unk0 = arg0;
+    } else {
+        D_8002DA60 = arg0;
+    }
+    D_8001F7A0++;
+    if ((u32) D_8001F7A4 < (u32) D_8001F7A0) {
+        D_8001F7A4 = D_8001F7A0;
+    }
+}
+
+
+#pragma GLOBAL_ASM("asm/us/nonmatchings/3630/func_80002CD0.s")
+
+#pragma GLOBAL_ASM("asm/us/nonmatchings/3630/func_80002EAC.s")
+
+#pragma GLOBAL_ASM("asm/us/nonmatchings/3630/func_80002F4C.s")
+
+#pragma GLOBAL_ASM("asm/us/nonmatchings/3630/func_80002F6C.s")
+
+#pragma GLOBAL_ASM("asm/us/nonmatchings/3630/func_800031A8.s")
+
+#pragma GLOBAL_ASM("asm/us/nonmatchings/3630/func_80003240.s")
+
+#pragma GLOBAL_ASM("asm/us/nonmatchings/3630/func_80003294.s")
+
+#pragma GLOBAL_ASM("asm/us/nonmatchings/3630/func_800032C4.s")
+
+#pragma GLOBAL_ASM("asm/us/nonmatchings/3630/func_800032E4.s")
+
+#pragma GLOBAL_ASM("asm/us/nonmatchings/3630/func_80003310.s")
+
+#pragma GLOBAL_ASM("asm/us/nonmatchings/3630/func_80003494.s")
+
+#pragma GLOBAL_ASM("asm/us/nonmatchings/3630/func_800034E0.s")
+
+#pragma GLOBAL_ASM("asm/us/nonmatchings/3630/func_80003520.s")
+
+#pragma GLOBAL_ASM("asm/us/nonmatchings/3630/func_8000355C.s")
+
+#pragma GLOBAL_ASM("asm/us/nonmatchings/3630/func_80003584.s")
+
+#pragma GLOBAL_ASM("asm/us/nonmatchings/3630/func_80003760.s")
+
+#pragma GLOBAL_ASM("asm/us/nonmatchings/3630/func_80003790.s")
+
+#pragma GLOBAL_ASM("asm/us/nonmatchings/3630/func_80003A14.s")
+
+#pragma GLOBAL_ASM("asm/us/nonmatchings/3630/func_80003AF0.s")
+
+#pragma GLOBAL_ASM("asm/us/nonmatchings/3630/func_80003B64.s")
+
+#pragma GLOBAL_ASM("asm/us/nonmatchings/3630/func_80003B80.s")
+
+#pragma GLOBAL_ASM("asm/us/nonmatchings/3630/func_80003C1C.s")
+
+#pragma GLOBAL_ASM("asm/us/nonmatchings/3630/func_80003CEC.s")
+
+#pragma GLOBAL_ASM("asm/us/nonmatchings/3630/func_80003E0C.s")
+
+#pragma GLOBAL_ASM("asm/us/nonmatchings/3630/func_80003E94.s")
+
+#pragma GLOBAL_ASM("asm/us/nonmatchings/3630/func_80003F04.s")
+
+#pragma GLOBAL_ASM("asm/us/nonmatchings/3630/func_80004014.s")
+
+#pragma GLOBAL_ASM("asm/us/nonmatchings/3630/func_80004088.s")
+
+#pragma GLOBAL_ASM("asm/us/nonmatchings/3630/func_80004274.s")
+
+#pragma GLOBAL_ASM("asm/us/nonmatchings/3630/func_80004284.s")
+
+#pragma GLOBAL_ASM("asm/us/nonmatchings/3630/func_80004298.s")
+
+#pragma GLOBAL_ASM("asm/us/nonmatchings/3630/func_800042DC.s")
+
+#pragma GLOBAL_ASM("asm/us/nonmatchings/3630/func_800042E4.s")
+
+#pragma GLOBAL_ASM("asm/us/nonmatchings/3630/func_800043E4.s")
+
+#pragma GLOBAL_ASM("asm/us/nonmatchings/3630/func_800046EC.s")
+
+#pragma GLOBAL_ASM("asm/us/nonmatchings/3630/func_8000481C.s")
+
+#pragma GLOBAL_ASM("asm/us/nonmatchings/3630/func_8000487C.s")
+
+#pragma GLOBAL_ASM("asm/us/nonmatchings/3630/func_800048C8.s")
+
+#pragma GLOBAL_ASM("asm/us/nonmatchings/3630/func_800048D4.s")
+
+void func_800048DC(void) {
+}
+
+#pragma GLOBAL_ASM("asm/us/nonmatchings/3630/func_800048E4.s")
+
+#pragma GLOBAL_ASM("asm/us/nonmatchings/3630/func_80004958.s")
+
+#pragma GLOBAL_ASM("asm/us/nonmatchings/3630/func_80004A78.s")
+
+#pragma GLOBAL_ASM("asm/us/nonmatchings/3630/func_80004A84.s")
+
+#pragma GLOBAL_ASM("asm/us/nonmatchings/3630/func_80004B1C.s")
+
+#pragma GLOBAL_ASM("asm/us/nonmatchings/3630/func_80004B2C.s")

--- a/src/memory.c
+++ b/src/memory.c
@@ -1,0 +1,104 @@
+#include "common.h"
+
+void _uvMediaCopy(void* vAddr, void* devAddr, u32 nbytes) {
+    s32 i;
+    u8 *alignCeil;
+    s32 alignDiff;
+    u8 *src;
+    u8 buf[16];
+    u8 *dst;
+    s32 temp_a2;
+    s32 temp_v0;
+
+    dst = vAddr;
+    src = devAddr;
+    if ((u32)src & 0x80000000) {
+        for (i = 0; (u32)i < nbytes; i++) {
+            dst[i] = src[i];
+        }
+        return;
+    }
+
+    while (nbytes > 0x1000) {
+        _uvMediaCopy(dst, src, 0x1000);
+        nbytes -= 0x1000;
+        dst += 0x1000;
+        src += 0x1000;
+    }
+
+    if (nbytes != 0) {
+        if (((s32)src | (s32) dst | nbytes) & 1) {
+            // it appears the devs intended to cause a fault by storing to an unaligned address,
+            // but IDO outsmarted them and broke this into two `sb` instructions
+            // Debug Print removed..
+            *(u16*)(1) = 0;
+            return;
+        }
+        if ((s32)dst & 7) {
+            alignCeil = (u8*)((s32)(dst + 7) & ~7);
+            alignDiff = alignCeil - dst;
+            temp_a2 = (u32)src & 2;
+            
+            if ((nbytes != (u32)alignDiff) != 0) {
+                _uvDMA(alignCeil, src + alignDiff, nbytes - alignDiff);
+            }
+            temp_v0 = src - temp_a2;
+            
+            osPiWriteIo(temp_v0, &buf[0]);
+            osPiWriteIo(temp_v0 + 4, &buf[4]);
+            if (temp_a2) {
+                osPiWriteIo(temp_v0 + 8, &buf[8]);
+            }
+            for (i = 0; i < alignDiff && i < nbytes; i++) {
+                dst[i] = buf[i + temp_a2];
+            }
+            
+        } else {
+            _uvDMA(dst, src, nbytes);
+        }
+    }
+}
+
+void uvMemSet(void* vAddr, u8 value, u32 nbytes) {
+    u32 count;
+    u8* dest;
+
+    count = 0;
+    if (nbytes != 0) {
+        dest = vAddr;
+        do {
+            count += 1;
+            *dest++ = value;
+        } while (count < nbytes);
+    }
+}
+
+u64 uvMemRead(void* vAddr, u32 nbytes) {
+    u64 out; // sp38
+    u64 temp1;
+    s64 sp28;
+    u8* src;
+
+    src = vAddr;
+    if ((nbytes != 1) && (nbytes != 2) && (nbytes != 4) && (nbytes != 8)) {
+        out = 0;
+    } else if ((s32) vAddr & 0x80000000) {
+        out = src[0];
+        if (nbytes >= 2U) {
+            temp1 = out << 8;
+            out = temp1 | src[1];
+        }
+        if (nbytes >= 3U) {
+            temp1 = out << 16;
+            out = temp1 | (src[2] << 8) | src[3];
+        }
+        if (nbytes >= 5U) {
+            temp1 = out << 32;
+            out = temp1 | (src[4] << 0x18) | (src[5] << 0x10) | (src[6] << 8) | src[7];
+        }
+    } else {
+        _uvMediaCopy(&sp28, vAddr, nbytes); // _uvMediaCopy
+        out = uvMemRead(&sp28, nbytes);
+    }
+    return out;
+}


### PR DESCRIPTION
- Match `2FE0`
- Split two files from `2FE0`: `32BE0` (now `memory`) and `3630`
- Some matches in `3630`