### PR TITLE
Fix nested f-string quotes for Python < 3.12

### DIFF
--- a/tools/moduleFileDisasm.py
+++ b/tools/moduleFileDisasm.py
@@ -408,7 +408,7 @@ def renameFunctions(processedFiles: dict[common.FileSectionType, list[mips.secti
                 continue
             # Don't rename the functions specified in the symbol addrs file
             if dic.get(func.contextSym.name) != func.getVramOffset(0):
-                func.contextSym.name =   "func_" + moduleName + "_" + f"{hex(func.getVramOffset(0)).replace("0x", "00").upper()}"
+                func.contextSym.name =   "func_" + moduleName + "_" + f"{hex(func.getVramOffset(0)).replace('0x', '00').upper()}"
 
 
 
@@ -465,9 +465,9 @@ def writeSourceFile(processedFiles: dict[common.FileSectionType, list[mips.secti
             for func in textFile.symbolList:
                 assert isinstance(func, mips.symbols.SymbolFunction)
                 if func.getVramOffset(0) == entryFuncVaddr:
-                    globalAsmFunc = "asm/us/nonmatchings/modules/" + moduleName + "/" + "__entrypoint_func_" + moduleName + "_" + f"{hex(func.getVramOffset(0)).replace("0x", "")}" + ".s"
+                    globalAsmFunc = "asm/us/nonmatchings/modules/" + moduleName + "/" + "__entrypoint_func_" + moduleName + "_" + f"{hex(func.getVramOffset(0)).replace('0x', '')}" + ".s"
                 else:
-                    globalAsmFunc = "asm/us/nonmatchings/modules/" + moduleName + "/" + "func_" + moduleName + "_" + f"{hex(func.getVramOffset(0)).replace("0x", "00").upper()}" + ".s"
+                    globalAsmFunc = "asm/us/nonmatchings/modules/" + moduleName + "/" + "func_" + moduleName + "_" + f"{hex(func.getVramOffset(0)).replace('0x', '00').upper()}" + ".s"
                 f.write(f"#pragma GLOBAL_ASM(\"{globalAsmFunc}\")\n\n")
 
 


### PR DESCRIPTION
I know Python 3.12 allows this like with PEP 701, but to get this repo to build, I had to start from ubuntu:22.04, and if I do that and follow the installation commands given in README.md, it installs Python 3.10 - which gives syntax errors at the locations changed in this commit because they nest double-quotes in the f-strings.

This just replaces `"` with `'` there.