### PR TITLE
Fix missing dependencies in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Under Debian / Ubuntu (which we recommend using), you can install them with the 
 
 ```bash
 sudo apt update
-sudo apt install make git build-essential binutils-mips-linux-gnu python3 python3-pip clang-format-14 clang-tidy libcjson-dev
+sudo apt install make git build-essential binutils-mips-linux-gnu python3 python3-pip clang-format-14 clang-tidy libcjson-dev curl libzstd-dev binutils-dev
 ```
 
 ### MacOS

--- a/tools/daisybox/resolve_deps.sh
+++ b/tools/daisybox/resolve_deps.sh
@@ -1,5 +1,7 @@
 #https://ftp.gnu.org/gnu/binutils/binutils-2.46.0.tar.xz
 
+set -e
+
 BINUTILS_MIRROR=https://ftp.gnu.org/gnu/binutils/
 
 BINUTILS_VERSION=2.42


### PR DESCRIPTION
When building from ubuntu:22.04 in Docker (ubuntu:latest seems to have other issues), there are a few other dependencies besides what the README.md mentions (curl, binutils-dev, libzstd-dev).  In particular, "make dependencies" fails at a few points.

This also updates tools/daisybox/resolve_deps.sh to fail earlier if curl is missing - rather than run a series of commands that all fail and then give a somewhat unrelated error.

If curl is missing, it fails like below:

```
sh resolve_deps.sh
Downloading binutils version 2.42 from https://ftp.gnu.org/gnu/binutils/
resolve_deps.sh: 9: curl: not found
tar (child): binutils.tar.xz: Cannot open: No such file or directory
tar (child): Error is not recoverable: exiting now
tar: Child returned status 2
tar: Error is not recoverable: exiting now
resolve_deps.sh: 12: cd: can't cd to binutils-2.42
resolve_deps.sh: 13: ./configure: not found
Copying the required libraries to the lib directory
cp: target '../include' is not a directory
gcc -I. -I include -ggdb3 -O2 -Wall -Wextra -std=c11 -Wno-multichar -DLOG_USE_COLOR -c -o build/src/bar_module_files.o src/bar_module_files.c
gcc -I. -I include -ggdb3 -O2 -Wall -Wextra -std=c11 -Wno-multichar -DLOG_USE_COLOR -c -o build/src/daisybox.o src/daisybox.c
In file included from src/daisybox.c:1:
include/global.h:3:10: fatal error: config.h: No such file or directory
    3 | #include "config.h"
      |          ^~~~~~~~~~
compilation terminated.
make[2]: *** [Makefile:31: build/src/daisybox.o] Error 1
make[1]: *** [Makefile:18: default] Error 2
make: *** [Makefile:433: dependencies] Error 2
```

If missing binutils-dev, the following occurs:

```
Copying the required libraries to the lib directory
gcc -I. -I include -ggdb3 -O2 -Wall -Wextra -std=c11 -Wno-multichar -DLOG_USE_COLOR -c -o build/src/daisybox.o src/daisybox.c
In file included from include/global.h:12,
                 from src/daisybox.c:1:
include/bfd.h:43:10: fatal error: ansidecl.h: No such file or directory
   43 | #include "ansidecl.h"
      |          ^~~~~~~~~~~~
compilation terminated.
make[2]: *** [Makefile:31: build/src/daisybox.o] Error 1
make[1]: *** [Makefile:18: default] Error 2
make: *** [Makefile:433: dependencies] Error 2
```

If missing libzstd-dev, the following occurs:

```
gcc  -o daisybox build/src/bar_module_files.o build/src/daisybox.o build/src/load_reloc_order.o build/src/log.o build/src/map_symbols.o build/src/relocs_sort.o build/src/sym_tab.o build/src/utils.o  libs/libbfd.a libs/libopcodes.a libs/libsframe.a libs/libiberty.a libs/libz.a -lzstd -lm -ldl -lcjson
/usr/bin/ld: cannot find -lzstd: No such file or directory
collect2: error: ld returned 1 exit status
make[2]: *** [Makefile:28: daisybox] Error 1
make[1]: *** [Makefile:18: default] Error 2
make: *** [Makefile:433: dependencies] Error 2
```