### PR TITLE
Change "convert" target to use tools/m2ctx, not tools/m2ctx.py

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -498,7 +498,7 @@ expected:
 
 context:
 	@echo "Generating ctx.c ..."
-	@$(PYTHON) ./$(TOOLS)/m2ctx.py $(filter-out $@, $(MAKECMDGOALS))
+	@$(PYTHON) ./$(TOOLS)/m2ctx $(filter-out $@, $(MAKECMDGOALS))
 
 disasm:
 	@$(RM) -r asm/$(VERSION) bin/$(VERSION)


### PR DESCRIPTION
There is no tools/m2ctx.py; I am guessing this meant tools/m2ctx, which does exist and is a Python file.