### PR TITLE
Document snd entrypoint function

### DIFF
--- a/include/snd.h
+++ b/include/snd.h
@@ -74,257 +74,260 @@ typedef struct Snd_Exports_s {
 } Snd_Exports; /* size = 0xFC */
 
 enum SfxId {
-        BIGWTRFALL8,
-        WATER5,
-        SKID11,                 // tire skid (surprisingly bad loop)
-        CHEROKEECRUZ1L1,
-        CAMAROLOAD_PS22MB_L1,
-        CAMARO_CRUZ_L1,
-        BUMP15,
-        GRAVELSKID,
-        WETROADNOISE2,
-        BUMP12,
-        SPLASH,
+        /* 0x00 */ BIGWTRFALL8,
+        /* 0x01 */ WATER5,
+        /* 0x02 */ SKID11,                 // tire skid (surprisingly bad loop)
+        /* 0x03 */ CHEROKEECRUZ1L1,
+        /* 0x04 */ CAMAROLOAD_PS22MB_L1,
+        /* 0x05 */ CAMARO_CRUZ_L1,
+        /* 0x06 */ BUMP15,
+        /* 0x07 */ GRAVELSKID,
+        /* 0x08 */ WETROADNOISE2,
+        /* 0x09 */ BUMP12,
+        /* 0x0A */ SPLASH,
+        // It appears at some point during development, the soundNames were
+        // locked down and no further edits were made.  As a result,
         // the next four strings don't match up with the actual audio
-        S_DRIVE,                // this is actually S_HORN
-        S_HORN,                 // S_UP? (UI select)
-        S_KLUNK,                // gear shift sfx (unused?)
-        S_UP,                   // (UI cancel) (no matching soundName)
-        PHONEGAG,               // "We're sorry, your call..."
-        ICECRYSTALBREAK,
-        WOODSLAT,               // Sunset Sands wooden bridge?
-        AH1,                    // helicopter (fast)
-        CHINOOK,                // helicopter (slow)
-        UFO1,                   // UFO drone (far -growling)
-        UFO2,                   // UFO drone (close - harsh synth loop)
-        CROWDSKIJUMP,           // cheering crowd
-        MOBSKIJUMP,             // booing crowd after failed jump
-        GONDOLAS,               // squeaky cable car
-        FRZH2OFALL,             // frozen waterfall impact
-        STALACTITES,            // repurposed for Wicked Woods bridge breakable
-        RUSHINGH2O,             // rushing water
-        ID_UNKNOWN,             // (original ID string was "NULL")
-        ICECRACK1,              // Mount Mayhem frozen waterfall shortcut
-        STAINEDGLASS,           // Coventry / Wicked church glass impact
-        DIRTROAD,
-        GRAVELROAD,
-        METALSCRAPE,
-        PAVEDROAD,
-        SNOWROAD,
-        CRANEENGINE,            // Coventry Cove crane
-        CRANEWINCH,
-        TREE,                   // not sure where this is used
-        MINEENTER,              // Coventry mineshaft
-        TOLLBOOTH,              // Coventry bridge bar gate impact
-        PHONEBOOTH,
-        SAWHORSE,               // very similar to TOLLBOOTH
-        CARLDGSUSP,             // suspension squeak
-        BARRELEXPLODE,
-        SIGNHIT,                // road sign impact
-        ELEVATORDN,             // Sunset Sands elevator (with slam at end)
-        ELEVATORUP,             // shorter stone elevator scrape
-        H2OFALLECHO,            // Coventry Cove mineshaft waterfall?
-        FIRE,                   // generic fire sfx
-        WOODCREAK,
-        PILLARSTOPPLE,          // Sunset Sands pillars collapsing
-        POTTERYSMASH,
-        GARAGEDOOR,             // Mount Mayhem glass door impact
-        SNOWMAN5,               // snowman impact
-        SNOWSLIDE,
-        ICECRYSTALSMASH,        // final in-game version of ICECRYSTALBREAK
-        WICKERBASKET,           // Sunset Sands prop?
-        ELEVATORBELL,           // Sunset Sands elevator bell ding
-        SCAFFOLDCREAK,          // Sunset / Wicked wooden bridge
-        SCAFFOLDGROAN,
-        WIDESIGNHIT,            // another road sign impact
-        CAREXPLODE,
-        CTRAINTRACKS,           // Metro Madness city train
-        MOVIESCREEN,            // movie screen impact
-        GASPUMPEXPLODE,         // Metro Madness gas pump
-        BOARDEDTEMPLE,
-        WATERFOUNTAIN,
-        CARPUDDLESPLASH2,
-        CHAINLINKFENCE,
-        CONCRETESCRAPE,
-        CURBBUMP,
-        SLOTCOINSPULL,          // Metro Madness casino slot machine sfx
-        SLOTHANDLEPULL,
-        SLOTWINNER1,
-        SLOTWINNER2,
-        STANDSSKIJUMP,          // ski jump crowd screaming
-        CRATEEXPLODE,
-        TREXROAR,
-        LAVABUBBLES,
-        LOWRUMBLE,
-        JTRAINTRACKS,           // Inferno Isle train
-        CAMERA,                 // UI camera view change (same as S_KLUNK)
-        SNOW,
-        ICESKID,
-        MONKEYS,
-        ICETIRESPIN,
-        CONSTRUCTBARREL,
-        COBBLESTONEROAD,
-        MOVIEPROJECTOR,
-        TREXSTEP,               // t-rex footsteps
-        CANNONBALLSHOT,         // pirate ship shortcut
-        BULLFROG,
-        BUSH,
-        CRICKETS,
-        JUNGLEAMBIENT1,
-        ENGINE1CRUZ,            // player car engine sfx
-        ENGINE1LOAD,
-        ENGINE2CRUZ,
-        ENGINE2LOAD,
-        XINGBELL,               // Coventry Cove bridge bell
-        ROCKSLIDE,
-        CHURCH,                 // possibly unused?
-        SURF,                   // Inferno Isle beach waves
-        ENGINE3CRUZ,
-        ENGINE3LOAD,
-        INVINCIBILITY,          // Chrome Beetle power up
-        PWRUPNITRO,             // Nitro Box impact (Ya-hoo!)
-        DIRTSKID,
-        V_GO,                   // "Go!"
-        V_ONE,                  // "One!"
-        V_THREE,                // "Three!"
-        V_TWO,                  // "Two!"
-        V_FINISH,               // "Finish!"
-        V_LAPTWO,               // "Lap two!"
-        V_COVE,                 // "Welcome to...Coventry Cove"
-        V_WOODS,                // "Welcome to...Wicked Woods"
-        V_MAYHEM,               // "Welcome to...Mount Mayhem"
-        V_SANDS,                // "Welcome to...Sunset Sands"
-        V_INFERNO,              // "Welcome to...Inferno Isle"
-        V_METRO,                // "Welcome to...Metro Madness"
-        V_FINALLAP,             // "It's the final lap!"
-        V_TITLE,                // "Adventure Racing!"
-        V_HOWDY,                // "Welcome!"
-        HORNLOOP,               // annoying horn loop
-        POINTS_1,               // 2 point box xylophone jingle
-        POINTS_5,               // 5 point box jingle
-        POINTS_10,              // 10 point box jingle
-        MINEPLANT,              // Beetle Battle mine drop
-        MISSILESHOT,            // Beetle Battle missile
-        MISSILEHIT,             // unused?
-        MISSILEHIT1,
-        LADYBUG,                // Beetle Battle ladybug pickup
-        FORCEFIELD,             // Inferno Isle electric fence
-        HEALTH_GOOD1,           // "Now ya kickin'!"
-        HEALTH_BAD,             // "Oh no!" (Inferno Isle hut impact)
-        DRIVEWATER,
-        LAVAFALL,
-        V_SPLIT_30_1,           // "You're falling behind!"
-        V_SPLIT_30_2,           // "Pick up the pace!"
-        V_SPLIT_50_1,           // "Hurry up!"
-        V_SPLIT_50_2,           // "Pedal to the metal!"
-        V_SPLIT_60,             // "Disqualified!"
-        WATERWHEEL,             // Coventry Cove prop
-        JACK,                   // Wicked Woods jack-o-lantern laugh
-        PURPWIND,               // Wicked Woods wind howling and chimes
-        OWL,
-        SPOOKY,                 // haunted house ghostsooooh
-        SCREAM,                 // Wicked Woods dungeon shortcut
-        CHAINS,
-        BATS,
-        LASTLADYBUG,            // "Head for the exit!"
-        WOLVES,                 // spooky wolves howling
-        COPSIREN,
-        TORCHBREAK,             // fire torch snap
-        CHROMECAR,              // Chrome Beetle drone
-        PLYRHORN,
-        CARLDGLITE,             // car jump landing
-        WWCLKCHIME,             // Wicked Woods clock tower chime
-        INVERT,                 // "Trip out"
-        FOGWEAPON,              // "Get funky"
-        V_WINNER,               // "Winner, winner, winner!"
-        V_BATTLE1,              // "Let's get it on"
-        V_BATTLE2,              // "Get down!"
-        V_BATTLE3,              // "Here we go!"
-        V_BATTLE4,              // "Let's get busy!"
-        V_BONUS_50,             // "You got it!"
-        V_BONUS_100,            // "You got them all!"
-        V_GAME_OVER,            // "Game over!"
-        V_READY,                // "Get ready!"
-        STEALERHIT,             // Beetle Battle stealer hit laugh
-        S_CONFIRM,              // UI confirm
-        HEALTH_GOOD2,           // "Baby!"
-        HEALTH_BAD_B1,          // "Nasty!"
-        HEALTH_BAD_B2,          // "That's cold, baby!"
-        BATTLEEXPLODE1,         // "Dyno-mite!"
-        BATTLEEXPLODE2,         // "That's gotta hurt!" (Blu V.O.)
-        BATTLEEXPLODE3,         // "You bad!"
-        V_WINNER_A,             // "Awwww, yeaaaah!"
-        V_WINNER_B,             // "Hail to the king, baby!"
-        V_WINNER_C,             // "You're bumpin' with the flava now!"
-        V_GROOVY,               // "Grrrrrooovy!"
-        V_NICEWHL,              // "Nice wheels!"
-        V_BEETLEBAT,            // "Beetle Battle"
-        V_DUEL,                 // "Duel"
-        V_ONE_PLAYER,           // "One Player"
-        V_OPTIONS,              // "Options"
-        V_RECORDS,              // "Records"
-        V_OK,                   // "Ok!"
-        DRAGON,                 // Dragon growling (unused)
-        SLAMDOOR,               // Haunted door slamming loop (infamous glitch)
-        V_NOVICE,               // "Novice circuit"
-        V_ADVANCED,             // "Advanced circuit"
-        V_PRO,                  // "Pro circuit"
-        V_BONUS,                // "Bonus circuit"
-        DRAGONFIRE,             // Dragon roaring and flames
-        UFOMOVIE,               // Metro Madness movie theater sfx
-        V_RECORDSET,            // "Record!"
-        V_PLACE1,               // "First place!"
-        V_PLACE2,               // "Second place!"
-        V_PLACE3,               // "Third place!"
-        V_PLACE4,               // "Fourth place!"
-        V_PLACE5,               // "Fifth"
-        V_PLACE6,               // "Sixth"
-        V_PLACE7,               // "Seventh"
-        V_PLACE8,               // "Eigth"
-        V_YOU_PLACED,           // "You placed..."
-        V_PLACE1A,              // "Congratulations!"
-        V_PLACE1B,              // "Way to go!"
-        V_PLACE1C,              // "You got first!"
-        V_PLACE234A,            // "Great race!"
-        V_PLACE5678A,           // "Nice try"
-        V_PLACE8B,              // "Last place?!"
-        V_PLACE8C,              // "You'll never win that way!"
-        V_PLACE8D,              // "Dead last!"
-        V_CONTINUE,             // "You're still in the game!"
-        V_CHAMPSTOP1,           // "Better luck next time"
-        V_CHAMPSTOP2,           // "Practice makes perfect!"
-        V_CHAMPSTOP3,           // "You can do better"
-        S_JOY_LR,               // UI select (left/right)
-        V_AWARD_A,              // "Well done, you cleared advanced..."
-        V_AWARD_N,              // "Congratulations, you won novice..."
-        V_AWARD_P,              // "Buckle up and hit the bonus circuit, baby!"
-        SLOWDOWN,               // "Funk-a-delic!"
-        V_SINGLRACE,            // "Single race"
-        V_CHAMPNSHIP,           // "Championship"
-        V_FULL_GRID,            // "Full Grid"
-        V_TIME_ATAK,            // "Time Attack"
-        V_GOODCHOICE,           // "Good choice!"
-        V_MULTIPLYR,            // "Two player"
-        HORN2LOOP,
-        HORN3LOOP,
-        HORN4LOOP,
-        ALIENHORN,              // "We come in peace"
-        V_HOTLAVA,              // "Hot lava!! Huuh!"
-        V_NEW_CONT,             // "You got a continue!"
-        V_NEW_ARENA,            // "A new arena!"
-        V_ALLRIGHT,             // "Allright!" (10 point box hit)
-        V_THREEPLYR,            // "Three player"
-        V_FOURPLYR,             // "Four player"
-        V_EXPLOSION,            // "Ooh! That's gotta hurt!" (David V.O.)
-        CROWDCLAP,              // Championship win
-        CROWDCHEER,             // Bonus championship win
-        CROWDMOAN,              // unused?
-        V_CHEATMENU,            // "Cheat menu activated!"
-        V_GOTCHEAT,             // "New cheat activated!"
-        V_TRYAGAIN,             // "Nice try, but you need to get first"
-        S_TALLYBELL,            // finish tallying points
-        S_TALLYCOUNT,           // tallying points for championship
-        V_CHAMPION              // "You're the champion!"
+        /* 0x0B */ S_DRIVE,                // this is actually the NPC horn honk
+        /* 0x0C */ S_HORN,                 // S_UP? (UI select)
+        /* 0x0D */ S_KLUNK,                // gear shift sfx (reused for CAMERA)
+        /* 0x0E */ S_UP,                   // (UI cancel) (no matching soundName)
+        //
+        /* 0x0F */ PHONEGAG,               // "We're sorry, your call..."
+        /* 0x10 */ ICECRYSTALBREAK,
+        /* 0x11 */ WOODSLAT,               // Sunset Sands wooden bridge?
+        /* 0x12 */ AH1,                    // helicopter (fast)
+        /* 0x13 */ CHINOOK,                // helicopter (slow)
+        /* 0x14 */ UFO1,                   // UFO drone (far -growling)
+        /* 0x15 */ UFO2,                   // UFO drone (close - harsh synth loop)
+        /* 0x16 */ CROWDSKIJUMP,           // cheering crowd
+        /* 0x17 */ MOBSKIJUMP,             // booing crowd after failed jump
+        /* 0x18 */ GONDOLAS,               // squeaky cable car
+        /* 0x19 */ FRZH2OFALL,             // frozen waterfall impact
+        /* 0x1A */ STALACTITES,            // repurposed for Wicked Woods bridge breakable
+        /* 0x1B */ RUSHINGH2O,             // rushing water
+        /* 0x1C */ ID_UNKNOWN,             // (original ID string was "NULL")
+        /* 0x1D */ ICECRACK1,              // Mount Mayhem frozen waterfall shortcut
+        /* 0x1E */ STAINEDGLASS,           // Coventry / Wicked church glass impact
+        /* 0x1F */ DIRTROAD,
+        /* 0x20 */ GRAVELROAD,
+        /* 0x21 */ METALSCRAPE,
+        /* 0x22 */ PAVEDROAD,
+        /* 0x23 */ SNOWROAD,
+        /* 0x24 */ CRANEENGINE,            // Coventry Cove crane
+        /* 0x25 */ CRANEWINCH,
+        /* 0x26 */ TREE,                   // not sure where this is used
+        /* 0x27 */ MINEENTER,              // Coventry mineshaft
+        /* 0x28 */ TOLLBOOTH,              // Coventry bridge bar gate impact
+        /* 0x29 */ PHONEBOOTH,
+        /* 0x2A */ SAWHORSE,               // very similar to TOLLBOOTH
+        /* 0x2B */ CARLDGSUSP,             // suspension squeak
+        /* 0x2C */ BARRELEXPLODE,
+        /* 0x2D */ SIGNHIT,                // road sign impact
+        /* 0x2E */ ELEVATORDN,             // Sunset Sands elevator (with slam at end)
+        /* 0x2F */ ELEVATORUP,             // shorter stone elevator scrape
+        /* 0x30 */ H2OFALLECHO,            // Coventry Cove mineshaft waterfall?
+        /* 0x31 */ FIRE,                   // generic fire sfx
+        /* 0x32 */ WOODCREAK,
+        /* 0x33 */ PILLARSTOPPLE,          // Sunset Sands pillars collapsing
+        /* 0x34 */ POTTERYSMASH,
+        /* 0x35 */ GARAGEDOOR,             // Mount Mayhem glass door impact
+        /* 0x36 */ SNOWMAN5,               // snowman impact
+        /* 0x37 */ SNOWSLIDE,
+        /* 0x38 */ ICECRYSTALSMASH,        // final in-game version of ICECRYSTALBREAK
+        /* 0x39 */ WICKERBASKET,           // Sunset Sands prop?
+        /* 0x3A */ ELEVATORBELL,           // Sunset Sands elevator bell ding
+        /* 0x3B */ SCAFFOLDCREAK,          // Sunset / Wicked wooden bridge
+        /* 0x3C */ SCAFFOLDGROAN,
+        /* 0x3D */ WIDESIGNHIT,            // another road sign impact
+        /* 0x3E */ CAREXPLODE,
+        /* 0x3F */ CTRAINTRACKS,           // Metro Madness city train
+        /* 0x40 */ MOVIESCREEN,            // movie screen impact
+        /* 0x41 */ GASPUMPEXPLODE,         // Metro Madness gas pump
+        /* 0x42 */ BOARDEDTEMPLE,
+        /* 0x43 */ WATERFOUNTAIN,
+        /* 0x44 */ CARPUDDLESPLASH2,
+        /* 0x45 */ CHAINLINKFENCE,
+        /* 0x46 */ CONCRETESCRAPE,
+        /* 0x47 */ CURBBUMP,
+        /* 0x48 */ SLOTCOINSPULL,          // Metro Madness casino slot machine sfx
+        /* 0x49 */ SLOTHANDLEPULL,
+        /* 0x4A */ SLOTWINNER1,
+        /* 0x4B */ SLOTWINNER2,
+        /* 0x4C */ STANDSSKIJUMP,          // ski jump crowd screaming
+        /* 0x4D */ CRATEEXPLODE,
+        /* 0x4E */ TREXROAR,
+        /* 0x4F */ LAVABUBBLES,
+        /* 0x50 */ LOWRUMBLE,
+        /* 0x51 */ JTRAINTRACKS,           // Inferno Isle train
+        /* 0x52 */ CAMERA,                 // UI camera view change (same as S_KLUNK)
+        /* 0x53 */ SNOW,
+        /* 0x54 */ ICESKID,
+        /* 0x55 */ MONKEYS,
+        /* 0x56 */ ICETIRESPIN,
+        /* 0x57 */ CONSTRUCTBARREL,
+        /* 0x58 */ COBBLESTONEROAD,
+        /* 0x59 */ MOVIEPROJECTOR,
+        /* 0x5A */ TREXSTEP,               // t-rex footsteps
+        /* 0x5B */ CANNONBALLSHOT,         // pirate ship shortcut
+        /* 0x5C */ BULLFROG,
+        /* 0x5D */ BUSH,
+        /* 0x5E */ CRICKETS,
+        /* 0x5F */ JUNGLEAMBIENT1,
+        /* 0x60 */ ENGINE1CRUZ,            // player car engine sfx
+        /* 0x61 */ ENGINE1LOAD,
+        /* 0x62 */ ENGINE2CRUZ,
+        /* 0x63 */ ENGINE2LOAD,
+        /* 0x64 */ XINGBELL,               // Coventry Cove bridge bell
+        /* 0x65 */ ROCKSLIDE,
+        /* 0x66 */ CHURCH,                 // possibly unused?
+        /* 0x67 */ SURF,                   // Inferno Isle beach waves
+        /* 0x68 */ ENGINE3CRUZ,
+        /* 0x69 */ ENGINE3LOAD,
+        /* 0x6A */ INVINCIBILITY,          // Chrome Beetle power up
+        /* 0x6B */ PWRUPNITRO,             // Nitro Box impact (Ya-hoo!)
+        /* 0x6C */ DIRTSKID,
+        /* 0x6D */ V_GO,                   // "Go!"
+        /* 0x6E */ V_ONE,                  // "One!"
+        /* 0x6F */ V_THREE,                // "Three!"
+        /* 0x70 */ V_TWO,                  // "Two!"
+        /* 0x71 */ V_FINISH,               // "Finish!"
+        /* 0x72 */ V_LAPTWO,               // "Lap two!"
+        /* 0x73 */ V_COVE,                 // "Welcome to...Coventry Cove"
+        /* 0x74 */ V_WOODS,                // "Welcome to...Wicked Woods"
+        /* 0x75 */ V_MAYHEM,               // "Welcome to...Mount Mayhem"
+        /* 0x76 */ V_SANDS,                // "Welcome to...Sunset Sands"
+        /* 0x77 */ V_INFERNO,              // "Welcome to...Inferno Isle"
+        /* 0x78 */ V_METRO,                // "Welcome to...Metro Madness"
+        /* 0x79 */ V_FINALLAP,             // "It's the final lap!"
+        /* 0x7A */ V_TITLE,                // "Adventure Racing!"
+        /* 0x7B */ V_HOWDY,                // "Welcome!"
+        /* 0x7C */ HORNLOOP,               // annoying horn loop
+        /* 0x7D */ POINTS_1,               // 2 point box xylophone jingle
+        /* 0x7E */ POINTS_5,               // 5 point box jingle
+        /* 0x7F */ POINTS_10,              // 10 point box jingle
+        /* 0x80 */ MINEPLANT,              // Beetle Battle mine drop
+        /* 0x81 */ MISSILESHOT,            // Beetle Battle missile
+        /* 0x82 */ MISSILEHIT,             // unused?
+        /* 0x83 */ MISSILEHIT1,
+        /* 0x84 */ LADYBUG,                // Beetle Battle ladybug pickup
+        /* 0x85 */ FORCEFIELD,             // Inferno Isle electric fence
+        /* 0x86 */ HEALTH_GOOD1,           // "Now ya kickin'!"
+        /* 0x87 */ HEALTH_BAD,             // "Oh no!" (Inferno Isle hut impact)
+        /* 0x88 */ DRIVEWATER,
+        /* 0x89 */ LAVAFALL,
+        /* 0x8A */ V_SPLIT_30_1,           // "You're falling behind!"
+        /* 0x8B */ V_SPLIT_30_2,           // "Pick up the pace!"
+        /* 0x8C */ V_SPLIT_50_1,           // "Hurry up!"
+        /* 0x8D */ V_SPLIT_50_2,           // "Pedal to the metal!"
+        /* 0x8E */ V_SPLIT_60,             // "Disqualified!"
+        /* 0x8F */ WATERWHEEL,             // Coventry Cove prop
+        /* 0x90 */ JACK,                   // Wicked Woods jack-o-lantern laugh
+        /* 0x91 */ PURPWIND,               // Wicked Woods wind howling and chimes
+        /* 0x92 */ OWL,
+        /* 0x93 */ SPOOKY,                 // haunted house ghostsooooh
+        /* 0x94 */ SCREAM,                 // Wicked Woods dungeon shortcut
+        /* 0x95 */ CHAINS,
+        /* 0x96 */ BATS,
+        /* 0x97 */ LASTLADYBUG,            // "Head for the exit!"
+        /* 0x98 */ WOLVES,                 // spooky wolves howling
+        /* 0x99 */ COPSIREN,
+        /* 0x9A */ TORCHBREAK,             // fire torch snap
+        /* 0x9B */ CHROMECAR,              // Chrome Beetle drone
+        /* 0x9C */ PLYRHORN,
+        /* 0x9D */ CARLDGLITE,             // car jump landing
+        /* 0x9E */ WWCLKCHIME,             // Wicked Woods clock tower chime
+        /* 0x9F */ INVERT,                 // "Trip out"
+        /* 0xA0 */ FOGWEAPON,              // "Get funky"
+        /* 0xA1 */ V_WINNER,               // "Winner, winner, winner!"
+        /* 0xA2 */ V_BATTLE1,              // "Let's get it on"
+        /* 0xA3 */ V_BATTLE2,              // "Get down!"
+        /* 0xA4 */ V_BATTLE3,              // "Here we go!"
+        /* 0xA5 */ V_BATTLE4,              // "Let's get busy!"
+        /* 0xA6 */ V_BONUS_50,             // "You got it!"
+        /* 0xA7 */ V_BONUS_100,            // "You got them all!"
+        /* 0xA8 */ V_GAME_OVER,            // "Game over!"
+        /* 0xA9 */ V_READY,                // "Get ready!"
+        /* 0xAA */ STEALERHIT,             // Beetle Battle stealer hit laugh
+        /* 0xAB */ S_CONFIRM,              // UI confirm
+        /* 0xAC */ HEALTH_GOOD2,           // "Baby!"
+        /* 0xAD */ HEALTH_BAD_B1,          // "Nasty!"
+        /* 0xAE */ HEALTH_BAD_B2,          // "That's cold, baby!"
+        /* 0xAF */ BATTLEEXPLODE1,         // "Dyno-mite!"
+        /* 0xB0 */ BATTLEEXPLODE2,         // "That's gotta hurt!" (Blu V.O.)
+        /* 0xB1 */ BATTLEEXPLODE3,         // "You bad!"
+        /* 0xB2 */ V_WINNER_A,             // "Awwww, yeaaaah!"
+        /* 0xB3 */ V_WINNER_B,             // "Hail to the king, baby!"
+        /* 0xB4 */ V_WINNER_C,             // "You're bumpin' with the flava now!"
+        /* 0xB5 */ V_GROOVY,               // "Grrrrrooovy!"
+        /* 0xB6 */ V_NICEWHL,              // "Nice wheels!"
+        /* 0xB7 */ V_BEETLEBAT,            // "Beetle Battle"
+        /* 0xB8 */ V_DUEL,                 // "Duel"
+        /* 0xB9 */ V_ONE_PLAYER,           // "One Player"
+        /* 0xBA */ V_OPTIONS,              // "Options"
+        /* 0xBB */ V_RECORDS,              // "Records"
+        /* 0xBC */ V_OK,                   // "Ok!"
+        /* 0xBD */ DRAGON,                 // Dragon growling (unused)
+        /* 0xBE */ SLAMDOOR,               // Haunted door slamming loop (infamous glitch)
+        /* 0xBF */ V_NOVICE,               // "Novice circuit"
+        /* 0xC0 */ V_ADVANCED,             // "Advanced circuit"
+        /* 0xC1 */ V_PRO,                  // "Pro circuit"
+        /* 0xC2 */ V_BONUS,                // "Bonus circuit"
+        /* 0xC3 */ DRAGONFIRE,             // Dragon roaring and flames
+        /* 0xC4 */ UFOMOVIE,               // Metro Madness movie theater sfx
+        /* 0xC5 */ V_RECORDSET,            // "Record!"
+        /* 0xC6 */ V_PLACE1,               // "First place!"
+        /* 0xC7 */ V_PLACE2,               // "Second place!"
+        /* 0xC8 */ V_PLACE3,               // "Third place!"
+        /* 0xC9 */ V_PLACE4,               // "Fourth place!"
+        /* 0xCA */ V_PLACE5,               // "Fifth"
+        /* 0xCB */ V_PLACE6,               // "Sixth"
+        /* 0xCC */ V_PLACE7,               // "Seventh"
+        /* 0xCD */ V_PLACE8,               // "Eigth"
+        /* 0xCE */ V_YOU_PLACED,           // "You placed..."
+        /* 0xCF */ V_PLACE1A,              // "Congratulations!"
+        /* 0xD0 */ V_PLACE1B,              // "Way to go!"
+        /* 0xD1 */ V_PLACE1C,              // "You got first!"
+        /* 0xD2 */ V_PLACE234A,            // "Great race!"
+        /* 0xD3 */ V_PLACE5678A,           // "Nice try"
+        /* 0xD4 */ V_PLACE8B,              // "Last place?!"
+        /* 0xD5 */ V_PLACE8C,              // "You'll never win that way!"
+        /* 0xD6 */ V_PLACE8D,              // "Dead last!"
+        /* 0xD7 */ V_CONTINUE,             // "You're still in the game!"
+        /* 0xD8 */ V_CHAMPSTOP1,           // "Better luck next time"
+        /* 0xD9 */ V_CHAMPSTOP2,           // "Practice makes perfect!"
+        /* 0xDA */ V_CHAMPSTOP3,           // "You can do better"
+        /* 0xDB */ S_JOY_LR,               // UI select (left/right)
+        /* 0xDC */ V_AWARD_A,              // "Well done, you cleared advanced..."
+        /* 0xDD */ V_AWARD_N,              // "Congratulations, you won novice..."
+        /* 0xDE */ V_AWARD_P,              // "Buckle up and hit the bonus circuit, baby!"
+        /* 0xDF */ SLOWDOWN,               // "Funk-a-delic!"
+        /* 0xE0 */ V_SINGLRACE,            // "Single race"
+        /* 0xE1 */ V_CHAMPNSHIP,           // "Championship"
+        /* 0xE2 */ V_FULL_GRID,            // "Full Grid"
+        /* 0xE3 */ V_TIME_ATAK,            // "Time Attack"
+        /* 0xE4 */ V_GOODCHOICE,           // "Good choice!"
+        /* 0xE5 */ V_MULTIPLYR,            // "Two player"
+        /* 0xE6 */ HORN2LOOP,
+        /* 0xE7 */ HORN3LOOP,
+        /* 0xE8 */ HORN4LOOP,
+        /* 0xE9 */ ALIENHORN,              // "We come in peace"
+        /* 0xEA */ V_HOTLAVA,              // "Hot lava!! Huuh!"
+        /* 0xEB */ V_NEW_CONT,             // "You got a continue!"
+        /* 0xEC */ V_NEW_ARENA,            // "A new arena!"
+        /* 0xED */ V_ALLRIGHT,             // "Allright!" (10 point box hit)
+        /* 0xEE */ V_THREEPLYR,            // "Three player"
+        /* 0xEF */ V_FOURPLYR,             // "Four player"
+        /* 0xF0 */ V_EXPLOSION,            // "Ooh! That's gotta hurt!" (David V.O.)
+        /* 0xF1 */ CROWDCLAP,              // Championship win
+        /* 0xF2 */ CROWDCHEER,             // Bonus championship win
+        /* 0xF3 */ CROWDMOAN,              // unused?
+        /* 0xF4 */ V_CHEATMENU,            // "Cheat menu activated!"
+        /* 0xF5 */ V_GOTCHEAT,             // "New cheat activated!"
+        /* 0xF6 */ V_TRYAGAIN,             // "Nice try, but you need to get first"
+        /* 0xF7 */ S_TALLYBELL,            // finish tallying points
+        /* 0xF8 */ S_TALLYCOUNT,           // tallying points for championship
+        /* 0xF9 */ V_CHAMPION              // "You're the champion!"
 };
 
 #endif /* SND_H */

--- a/include/snd_info.h
+++ b/include/snd_info.h
@@ -1,4 +1,5 @@
-UnkStruct_snd_00406198 D_snd_00404610[250] = {
+#define SFX_TOTAL 250
+UnkStruct_snd_00406198 D_snd_00404610[SFX_TOTAL] = {
     {
         "BIGWTRFALL8         ",
         0x4E81,

--- a/src/modules/snd.c
+++ b/src/modules/snd.c
@@ -48,6 +48,14 @@ typedef struct UnkStruct_0040619C_s {
     s32 data[8];
 } UnkStruct_0040619C;
 
+typedef enum SoundType_e {
+    SOUND_TYPE_SFX,
+    SOUND_TYPE_SPEECH,
+    SOUND_TYPE_UI
+} SoundType;
+
+#define SFX_TOTAL 250
+
 void func_snd_004004F8(void);
 void func_snd_004005C8(void *arg0, s16 arg1, s32 arg2, f32 arg3, f32 arg4, f32 arg5,
                        UnkStruct_uvemitter_rom_004008CC *arg6);
@@ -180,8 +188,8 @@ void func_snd_00401DA0(UnkStruct_004005C8 *, s32);
 void __entrypoint_func_snd_400000(Snd_Exports *exports);
 
 void __entrypoint_func_snd_400000(Snd_Exports *arg0) {
-    s32 var_v0;
-    s32 sp28;
+    s32 soundType;
+    s32 sfxCount;
     u8 *temp_v0;
     u8 i;
     s32 j;
@@ -262,24 +270,32 @@ void __entrypoint_func_snd_400000(Snd_Exports *arg0) {
     sndSetSfxVol(gGameSettings->optionsSfxVol);
     sndSetSpeechVol(gGameSettings->optionsSpeechVol);
     gUvEmitterExports->func_uvemitter_rom_004029D8(2U, 1.0f);
-    sp28 = 250;
-    for (j = 0; j < sp28; j++) {
+    sfxCount = SFX_TOTAL;
+    for (j = 0; j < sfxCount; j++) {
         temp_v0 = func_snd_004023F4(j);
         if ((temp_v0[0] == 'V') && (temp_v0[1] == '_')) {
-            var_v0 = 1;
+            soundType = SOUND_TYPE_SPEECH;
         } else if ((temp_v0[0] == 'S') && (temp_v0[1] == '_')) {
-            var_v0 = 2;
+            soundType = SOUND_TYPE_UI;
         } else {
-            var_v0 = 0;
+            soundType = SOUND_TYPE_SFX;
         }
-        if (j == 0xB) {
-            var_v0 = 0;
+        // S_DRIVE is the NPC horn honk.  This reroutes the sound to the proper
+        // audio bus. It seems like these patches were added because there was 
+        // no time left to update the soundName strings.
+        if (j == S_DRIVE) {
+            soundType = SOUND_TYPE_SFX;
         }
-        if ((j == 0xAA) || (j == 0x86) || (j == 0xAC) || (j == 0xAD) || (j == 0xAE) || (j == 0x97)
-            || (j == 0xA0) || (j == 0xDF) || (j == 0x9F) || (j == 0xAF) || (j == 0xAF) || (j == 0xAF)) {
-            var_v0 = 1;
+        // Patch for routing mislabeled Beetle Battle speech sounds
+        if ((j == STEALERHIT) || (j == HEALTH_GOOD1) || (j == HEALTH_GOOD2) 
+            || (j == HEALTH_BAD_B1) || (j == HEALTH_BAD_B2) 
+            || (j == LASTLADYBUG) || (j == FOGWEAPON) || (j == SLOWDOWN) 
+            || (j == INVERT) || (j == BATTLEEXPLODE1) 
+            // !@bug: They forgot to add BATTLEEXPLODE2 and BATTLEEXPLODE3
+            || (j == BATTLEEXPLODE1) || (j == BATTLEEXPLODE1)) {
+            soundType = SOUND_TYPE_SPEECH;
         }
-        gUvEmitterExports->func_uvemitter_rom_004029A4(j, var_v0);
+        gUvEmitterExports->func_uvemitter_rom_004029A4(j, soundType);
     }
 }
 

--- a/src/modules/snd.c
+++ b/src/modules/snd.c
@@ -54,7 +54,6 @@ typedef enum SoundType_e {
     SOUND_TYPE_UI
 } SoundType;
 
-#define SFX_TOTAL 250
 
 void func_snd_004004F8(void);
 void func_snd_004005C8(void *arg0, s16 arg1, s32 arg2, f32 arg3, f32 arg4, f32 arg5,


### PR DESCRIPTION
It appears that the sfx `soundName` strings were locked down at some point during development.  They were unable to update the names and so there's some unusual patches to assign the proper `soundType` for these mislabled sounds.  Normally sounds are routed to the proper audio bus by a prefix (either `S_` or `V_`).  S sounds are for UI noises, while speech clips use V.  Not all speech sounds follow this naming scheme so patches were written to fix this.

My guess is that the speech for Beetle Battle was added late and instead of replacing the original strings for the placeholder Beetle Battle sfx, they did this instead.  

But as we can see, this introduced the error of excluding `BATTLEEXPLODE2` and `BATTLEEXPLODE3` from being routed to the proper speech type, so in theory they'll still play even if you turn speech volume off.